### PR TITLE
feat(loan): admin can approve or reject loan request

### DIFF
--- a/src/controllers/LoanController.js
+++ b/src/controllers/LoanController.js
@@ -51,6 +51,38 @@ class LoanController {
       data: loanRecord,
     });
   }
+
+  /**
+   * @method updateLoan
+   * @description Edit the status of the loan record
+   * @param {object} req Request object
+   * @param {object} res Response object
+   * @returns {object} JSON API Response
+   */
+  static updateLoan(req, res) {
+    const loanRecord = Loan.find(parseInt(req.params.id, 10));
+    if (!loanRecord) {
+      return res.status(404).json({
+        status: 404,
+        error: 'Loan record not found',
+      });
+    }
+
+    const data = req.body;
+    loanRecord.update(data);
+
+    return res.status(201).json({
+      status: 201,
+      data: {
+        loanId: loanRecord.id,
+        loanAmount: loanRecord.amount,
+        tenor: loanRecord.tenor,
+        status: loanRecord.status,
+        monthlyInstallment: loanRecord.paymentInstallment,
+        interest: loanRecord.interest,
+      },
+    });
+  }
 }
 
 export default LoanController;

--- a/src/models/Loan.js
+++ b/src/models/Loan.js
@@ -64,6 +64,19 @@ export default class Loan {
     );
   }
 
+  /**
+   * Update resource attribues
+   *
+   * @param {object} data attributes to modify
+   * @returns {Loan} loan resource
+   */
+  update(data) {
+    if (this.status === 'pending') {
+      this.status = data.status || this.status;
+    }
+    return this;
+  }
+
   static resetTable() {
     Loan.table = [];
     Loan.count = 0;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -51,5 +51,9 @@ router.patch(
   '/users/:email/verify',
   UserController.updateUser,
 );
+router.patch(
+  '/loans/:id',
+  LoanController.updateLoan,
+);
 
 export default router;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -432,4 +432,24 @@ describe('routes: loan', () => {
         });
     });
   });
+
+  context('PATCH /loans/<:loan-id>', () => {
+    const loan = Loan.table[0];
+    const { id } = loan;
+    const data = { status: 'approved' };
+
+    it('should update loan status successfully', (done) => {
+      chai
+        .request(app)
+        .patch(`${baseURI}/loans/${id}`)
+        .send(data)
+        .end((err, res) => {
+          expect(res).to.have.status(201);
+          expect(res.body).to.have.property('data');
+          expect(res.body.data).to.have.property('status');
+          expect(res.body.data.status).to.equal('approved');
+          done(err);
+        });
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- implements endpoint where admin can approve or reject a loan request

#### Description of Task to be completed?
- `PATCH /loans/<:loan-id>` endpoint

#### How should this be manually tested?
* git clone https://github.com/meetKazuki/QuickCredit.
* cd QuickCredit
* npm install
* npm test

#### Any background context you want to provide?
Nil

#### What are the relevant pivotal tracker stories?
#165772289

#### Screenshots (if appropriate)

#### Questions:
